### PR TITLE
feat(prescription): Allow multiple dosage lines

### DIFF
--- a/input/fsh/models/BeMedicationOrder-models.fsh
+++ b/input/fsh/models/BeMedicationOrder-models.fsh
@@ -20,7 +20,7 @@ Characteristics: #can-be-target
   * code 0..* CD "Reason for the prescription (typically diagnosis, or a procedure)"
   * text 0..1 ST "Reason for the prescription in textual form. This might not be allowed by some implementations."
 
-* dosage 1..1 DosagingInformation "Dosaging and administration instructions"
+* dosage 1..* DosagingInformation "Dosaging and administration instructions"
 
 
 * validFrom 0..1 DT "Effective date of the prescription. The prescription is not dispensable before this date. In most cases this information repeats issueDate"


### PR DESCRIPTION
To match what is possible in https://build.fhir.org/ig/hl7-be/medication/branches/v2/StructureDefinition-BEMedicationLine.html , since the creation of prescriptions from a medication line should reflect the input posology

![image](https://github.com/hl7-be/medication/assets/143497095/d5077add-820b-4429-b861-01a3990fbed9)

Example of such posology :
- Take 1 in the morning and 2 in the evening
- Take 2 + 1 if needed (like shown on https://github.com/hl7-be/medication/issues/193#issuecomment-2082200885 )
- ...